### PR TITLE
Fix trait bounds for recent Rust nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/detours/statik.rs
+++ b/src/detours/statik.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::{Function, GenericDetour};
+use std::marker::Tuple;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::{mem, ptr};
 
@@ -104,6 +105,7 @@ impl<T: Function> StaticDetour<T> {
   pub unsafe fn initialize<D>(&self, target: T, closure: D) -> Result<&Self>
   where
     D: Fn<T::Arguments, Output = T::Output> + Send + 'static,
+    <T as Function>::Arguments: Tuple,
   {
     let mut detour = Box::new(GenericDetour::new(target, self.ffi)?);
     if self
@@ -155,6 +157,7 @@ impl<T: Function> StaticDetour<T> {
   pub fn set_detour<C>(&self, closure: C)
   where
     C: Fn<T::Arguments, Output = T::Output> + Send + 'static,
+    <T as Function>::Arguments: Tuple,
   {
     let previous = self
       .closure
@@ -175,7 +178,10 @@ impl<T: Function> StaticDetour<T> {
 
   /// Returns a transient reference to the active detour.
   #[doc(hidden)]
-  pub fn __detour(&self) -> &dyn Fn<T::Arguments, Output = T::Output> {
+  pub fn __detour(&self) -> &dyn Fn<T::Arguments, Output = T::Output>
+  where
+    <T as Function>::Arguments: Tuple,
+  {
     // TODO: This is not 100% thread-safe in case the thread is stopped
     unsafe { self.closure.load(Ordering::SeqCst).as_ref() }
       .ok_or(Error::NotInitialized)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "1024"]
 #![cfg_attr(
   feature = "nightly",
-  feature(unboxed_closures, abi_thiscall)
+  feature(unboxed_closures, abi_thiscall, tuple_trait)
 )]
 #![cfg_attr(
   all(feature = "nightly", test),


### PR DESCRIPTION
On recent Rust nightlies, this crate fails to compile with the following error:

```
error[E0059]: type parameter to bare `Fn` trait must be a tuple
   --> C:\Users\andrea\.cargo\git\checkouts\detour-rs-4ad9facba90b8dd7\b0e6366\src\detours\statik.rs:106:8
    |
106 |     D: Fn<T::Arguments, Output = T::Output> + Send + 'static,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `<T as Function>::Arguments`
    |
note: required by a bound in `Fn`
help: consider further restricting the associated type
    |
106 |     D: Fn<T::Arguments, Output = T::Output> + Send + 'static, <T as Function>::Arguments: Tuple
    |                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0059]: type parameter to bare `Fn` trait must be a tuple
   --> C:\Users\andrea\.cargo\git\checkouts\detour-rs-4ad9facba90b8dd7\b0e6366\src\detours\statik.rs:157:8
    |
157 |     C: Fn<T::Arguments, Output = T::Output> + Send + 'static,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `<T as Function>::Arguments`
    |
note: required by a bound in `Fn`
help: consider further restricting the associated type
    |
157 |     C: Fn<T::Arguments, Output = T::Output> + Send + 'static, <T as Function>::Arguments: Tuple
For more information about this error, try `rustc --explain E0059`.
```

This patch addresses this issue.

P.S. I also added a `rust-toolchain.toml` file as it looks like this crate fails to compile without nightly anyway. Is that desirable?